### PR TITLE
Surfaces Updates: Callout, TeachingBubble, Coachmark

### DIFF
--- a/src/components/Callout/Callout.js
+++ b/src/components/Callout/Callout.js
@@ -25,6 +25,18 @@ const textHeadingSize = 'large';
 const textBodySize = 'medium';
 const stretch = 'stretch';
 
+const marker = (
+    <div
+        style={{
+            display: 'inline-block',
+            width: 20,
+            height: 20,
+            borderRadius: 10,
+            background: this.props.showMarker ? '#640487' : 'transparent',
+        }} >
+    </div>
+);
+
 
 
 class Callout extends React.Component {

--- a/src/components/Callout/Callout.js
+++ b/src/components/Callout/Callout.js
@@ -80,7 +80,7 @@ class Callout extends React.Component {
     }
 
     _onClick() {
-        //Clicking on the host control
+        //Clicking on the main control n the canvas
         if (this.props.trigger === tClick) {
             this._showControl();
         }

--- a/src/components/Callout/Callout.js
+++ b/src/components/Callout/Callout.js
@@ -41,8 +41,6 @@ class Callout extends React.Component {
         //Let's see if we can parse a real date
         let direction = this.props.direction;
 
-        console.log("Open: " + this.props.show);
-
         this.setState({
             ttDirection: direction,
             open: this.props.show,

--- a/src/components/Callout/Callout.js
+++ b/src/components/Callout/Callout.js
@@ -13,7 +13,7 @@ const coStackTokens = {
     padding: 6,
 };
 
-const tNone = "None";
+const tManual = "Manual";
 const tHover = "On Hover";
 const tClick = "On Click";
 
@@ -80,8 +80,15 @@ class Callout extends React.Component {
     }
 
     _onClick() {
+        //Clicking on the host control
         if (this.props.trigger === tClick) {
             this._showControl();
+        }
+    }
+
+    _onClickCallout() {
+        if (this.props.dismissOnClick) {
+            this._dismissControl();
         }
     }
 
@@ -198,9 +205,10 @@ class Callout extends React.Component {
                         doNotLayer={false}
                         target={`#${coTargetID}`}
                         directionalHint={DirectionalHint[this.props.direction]}
-                        onDismiss={() => { this._dismissControl() }}
                         setInitialFocus={true}
                         className={coStyles}
+                        onClick={() => { this._onClickCallout() }}
+                        onDismiss={() => { this._dismissControl() }}
                     >
                         {ttContents}
                     </MCallout>
@@ -241,10 +249,15 @@ Callout.propTypes = {
      * @uxpinpropname Trigger
      */
     trigger: PropTypes.oneOf([
-        tNone,
+        tManual,
         tClick,
         tHover
     ]),
+
+    /**
+     * @uxpindescription Whether to dismiss the control when the user clicks on anything contained within it, such as a link, button, or the control's background itself 
+     */
+    dismissOnClick: PropTypes.bool,
 
     /**
      * @uxpindescription The control's title text
@@ -298,8 +311,10 @@ Callout.propTypes = {
  */
 Callout.defaultProps = {
     showBeak: true,
+    showMarker: false,
     coWidth: coDefaultWidth,
     trigger: tClick,
+    dismissOnClick: false,
     title: "Callout",
     text: "Set a message and optionally add other Merge controls.",
     direction: "bottomCenter",

--- a/src/components/Callout/Callout.js
+++ b/src/components/Callout/Callout.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import { TooltipHost, } from '@fluentui/react/lib/Tooltip';
 import { Callout as MCallout } from '@fluentui/react/lib/Callout';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { Stack, StackItem } from '@fluentui/react/lib/Stack';

--- a/src/components/Callout/Callout.js
+++ b/src/components/Callout/Callout.js
@@ -25,18 +25,6 @@ const textHeadingSize = 'large';
 const textBodySize = 'medium';
 const stretch = 'stretch';
 
-const marker = (
-    <div
-        style={{
-            display: 'inline-block',
-            width: 20,
-            height: 20,
-            borderRadius: 10,
-            background: this.props.showMarker ? '#640487' : 'transparent',
-        }} >
-    </div>
-);
-
 
 
 class Callout extends React.Component {
@@ -114,7 +102,7 @@ class Callout extends React.Component {
     render() {
         const coTargetID = _.uniqueId('callout_');
 
-        var coChild = this.props.showMarker ? (
+        const marker = (
             <div
                 style={{
                     display: 'inline-block',
@@ -124,7 +112,9 @@ class Callout extends React.Component {
                     background: this.props.showMarker ? '#640487' : 'transparent',
                 }} >
             </div>
-        ) : '';
+        );
+
+        var coChild = marker;
 
         //To hold the list of contents
         var coList = [];
@@ -161,7 +151,7 @@ class Callout extends React.Component {
             let childList = React.Children.toArray(this.props.children);
 
             if (childList.length) {
-                //We only use the first child. All other children are ignored.
+                //The first child is the target for the popup control
                 coChild = childList[0];
 
                 if (childList.length > 1) {
@@ -184,7 +174,7 @@ class Callout extends React.Component {
             }
         }
 
-        //Reset the variable to the stack of objects
+        //Create the stack of objects
         let ttContents = (
             <Stack
                 tokens={coStackTokens}

--- a/src/components/Coachmark/Coachmark.js
+++ b/src/components/Coachmark/Coachmark.js
@@ -329,6 +329,7 @@ Coachmark.propTypes = {
 Coachmark.defaultProps = {
     show: true,
     showMarker: true,
+    extraWide: true,
     title: "Coachmark",
     text: "Set my 'Show' property to true to view me in a prototype.",
     direction: "bottomCenter",

--- a/src/components/Coachmark/Coachmark.js
+++ b/src/components/Coachmark/Coachmark.js
@@ -208,6 +208,7 @@ class Coachmark extends React.Component {
                             headline={this.props.title}
                             footerContent={footerText}
                             hasCloseIcon={true}
+                            isWide={this.props.extraWide}
                             primaryButtonProps={priBtnProps}
                             secondaryButtonProps={secBtnProps}
                             onDismiss={() => { this._onDismissClicked() }} >
@@ -245,6 +246,12 @@ Coachmark.propTypes = {
      * @uxpinpropname Show Marker
      */
     showMarker: PropTypes.bool,
+
+    /**
+     * @uxpindescription Whether to give the control extra width. 
+     * @uxpinpropname Extra Wide
+     * */
+    extraWide: PropTypes.bool,
 
     /**
      * @uxpindescription The control's title text

--- a/src/components/Coachmark/Coachmark.js
+++ b/src/components/Coachmark/Coachmark.js
@@ -328,12 +328,12 @@ Coachmark.propTypes = {
  */
 Coachmark.defaultProps = {
     show: true,
+    showMarker: true,
     title: "Coachmark",
-    text: "Welcome to the land of Coachmarks!",
+    text: "Set my 'Show' property to true to view me in a prototype.",
     direction: "bottomCenter",
     primaryButtonLabel: 'Next',
     secondaryButtonLabel: 'Close',
-    showMarker: true,
 }
 
 

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -3,7 +3,6 @@ import * as PropTypes from 'prop-types';
 import { TeachingBubble as FTeachingBubble } from '@fluentui/react/lib/TeachingBubble';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
 import { Stack, StackItem } from '@fluentui/react/lib/Stack';
-import { UxpImageUtils } from '../_helpers/uxpimageutils';
 
 
 
@@ -80,9 +79,6 @@ class TeachingBubble extends React.Component {
 
     render() {
         const tbTargetID = _.uniqueId('target_');
-
-        let imgURL = UxpImageUtils.getImageUrlByToken(this.props.imageUrl);
-        console.log("image url: " + imgURL);
 
         const marker = (<div
             style={{
@@ -180,7 +176,6 @@ class TeachingBubble extends React.Component {
                         {...this.props}
                         calloutProps={{ directionalHint: DirectionalHint[this.props.direction] }}
                         isWide={this.props.isWide}
-                        illustrationImage={imgURL}
                         headline={this.props.title}
                         footerContent={footerText}
                         hasCloseButton={this.props.hasCloseButton}
@@ -222,6 +217,12 @@ TeachingBubble.propTypes = {
     showMarker: PropTypes.bool,
 
     /**
+     * @uxpindescription Whether to give the control extra width. If true, the optional image is shown on the left side. 
+     * @uxpinpropname Is Wide
+     * */
+    isWide: PropTypes.bool,
+
+    /**
      * @uxpindescription The control's title text
      * @uxpinpropname Headline
      */
@@ -238,19 +239,6 @@ TeachingBubble.propTypes = {
     * @uxpinpropname Footer Text
     */
     footerText: PropTypes.string,
-
-    /**
-    * @uxpindescription The URL to an image file. Leave empty to display initials instead. Supports the Image Tokens feature, such as 'person1', 'bridge', 'office', and 'dog'. 
-    * @uxpinpropname Img URL
-    * @uxpincontroltype textfield(6)
-    */
-    imageUrl: PropTypes.string,
-
-    /**
-     * @uxpindescription Whether to give the control extra width. If true, the optional image is shown on the left side. 
-     * @uxpinpropname Is Wide
-     * */
-    isWide: PropTypes.bool,
 
     /**
      * @uxpindescription The displayed text on the Primary Button. Remove text to hide button.
@@ -320,7 +308,6 @@ TeachingBubble.defaultProps = {
     text: "Set my 'Show' property to true to view me in a mockup.",
     footerText: "",
     isWide: false,
-    imageUrl: '',
     direction: "bottomCenter",
     hasCloseButton: true,
     primaryButtonLabel: 'Next',

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -223,7 +223,7 @@ TeachingBubble.propTypes = {
     showMarker: PropTypes.bool,
 
     /**
-     * @uxpindescription Whether to give the control extra width. If true, the optional image is shown on the left side. 
+     * @uxpindescription Whether to give the control extra width
      * @uxpinpropname Extra Wide
      * */
     extraWide: PropTypes.bool,

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -95,7 +95,13 @@ class TeachingBubble extends React.Component {
 
         //If there are any props for the body message, add that first. 
         if (this.props.text && this.props.text?.trim()?.length > 0) {
-            coList.push(this.props.text.trim());
+            coList.push((
+                <StackItem
+                    align={stretch}
+                    grow={false}>
+                    {this.props.text.trim()}
+                </StackItem>
+            ));
         }
 
         if (this.props.children) {

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -311,7 +311,7 @@ TeachingBubble.propTypes = {
 TeachingBubble.defaultProps = {
     show: true,
     title: "Teaching Bubble",
-    text: "Set my 'Show' property to true to view me in a mockup.",
+    text: "Set my 'Show' property to true to view me in a prototype.",
     footerText: "",
     extraWide: false,
     direction: "bottomCenter",

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -175,7 +175,7 @@ class TeachingBubble extends React.Component {
                         target={`#${tbTargetID}`}
                         {...this.props}
                         calloutProps={{ directionalHint: DirectionalHint[this.props.direction] }}
-                        isWide={this.props.isWide}
+                        isWide={this.props.extraWide}
                         headline={this.props.title}
                         footerContent={footerText}
                         hasCloseButton={this.props.hasCloseButton}
@@ -218,9 +218,9 @@ TeachingBubble.propTypes = {
 
     /**
      * @uxpindescription Whether to give the control extra width. If true, the optional image is shown on the left side. 
-     * @uxpinpropname Is Wide
+     * @uxpinpropname Extra Wide
      * */
-    isWide: PropTypes.bool,
+    extraWide: PropTypes.bool,
 
     /**
      * @uxpindescription The control's title text
@@ -253,12 +253,6 @@ TeachingBubble.propTypes = {
     secondaryButtonLabel: PropTypes.string,
 
     /**
-     * @uxpindescription Whether to display the Close button
-     * @uxpinpropname Show Close Button
-     * */
-    hasCloseButton: PropTypes.bool,
-
-    /**
      * @uxpindescription The control's display direction
      * @uxpinpropname Direction
      */
@@ -278,6 +272,12 @@ TeachingBubble.propTypes = {
         "rightCenter",
         "rightBottomEdge"
     ]),
+
+    /**
+     * @uxpindescription Whether to display the Close button
+     * @uxpinpropname Show Close Button
+     * */
+    hasCloseButton: PropTypes.bool,
 
     /**
      * @uxpindescription Fires when the Close button is clicked
@@ -307,7 +307,7 @@ TeachingBubble.defaultProps = {
     title: "Teaching Bubble",
     text: "Set my 'Show' property to true to view me in a mockup.",
     footerText: "",
-    isWide: false,
+    extraWide: false,
     direction: "bottomCenter",
     hasCloseButton: true,
     primaryButtonLabel: 'Next',

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -82,6 +82,7 @@ class TeachingBubble extends React.Component {
         const tbTargetID = _.uniqueId('target_');
 
         let imgURL = UxpImageUtils.getImageUrlByToken(this.props.imageUrl);
+        console.log("image url: " + imgURL);
 
         const marker = (<div
             style={{

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -7,6 +7,7 @@ import { UxpImageUtils } from '../_helpers/uxpimageutils';
 
 
 
+const stretch = 'stretch';
 const coStackTokens = {
     childrenGap: 6,
     padding: 0,
@@ -97,7 +98,7 @@ class TeachingBubble extends React.Component {
 
         //If there are any props for the body message, add that first. 
         if (this.props.text && this.props.text?.trim()?.length > 0) {
-            coList.push(this.props.text?.trim());
+            coList.push(this.props.text.trim());
         }
 
         if (this.props.children) {

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -200,6 +200,14 @@ class TeachingBubble extends React.Component {
 TeachingBubble.propTypes = {
 
     /**
+     * Don't show this prop in the UXPin Editor. 
+     * @uxpinignoreprop 
+     * @uxpindescription Contents for the body of the control. 
+     * @uxpinpropname Children
+     */
+    children: PropTypes.node,
+
+    /**
      * @uxpindescription Whether to display the TeachingBubble 
      * @uxpinpropname Show
     */

--- a/src/components/TeachingBubble/TeachingBubble.js
+++ b/src/components/TeachingBubble/TeachingBubble.js
@@ -7,16 +7,6 @@ import { UxpImageUtils } from '../_helpers/uxpimageutils';
 
 
 
-const marker = (<div
-    className="trigger"
-    ref={this._targetElm}
-    style={{
-        width: 20,
-        height: 20,
-        background: this.props.showMarker ? '#b4009e' : 'transparent',
-        borderRadius: 4,
-    }} />);
-
 const coStackTokens = {
     childrenGap: 6,
     padding: 0,
@@ -91,6 +81,16 @@ class TeachingBubble extends React.Component {
         const tbTargetID = _.uniqueId('target_');
 
         let imgURL = UxpImageUtils.getImageUrlByToken(this.props.imageUrl);
+
+        const marker = (<div
+            style={{
+                width: 20,
+                height: 20,
+                background: this.props.showMarker ? '#b4009e' : 'transparent',
+                borderRadius: 4,
+            }} />);
+
+        var coChild = marker;
 
         //To hold the list of contents
         var coList = [];

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -123,6 +123,13 @@ class Text extends React.Component {
     </span >)
   }
 
+  _onClick() {
+    //Raise this event to UXPin. 
+    if (this.props.onClickText) {
+      this.props.onClickText(true);
+    }
+  }
+
   render() {
     //Let's see if the user entered a valid color value. This method returns undefined if not. 
     let textColor = UxpColors.getHexFromHexOrToken(this.props.color);
@@ -145,7 +152,9 @@ class Text extends React.Component {
         {...this.props}
         styles={fTextStyles}
         variant={this.props.size}
-        nowrap={this.props.truncate}>
+        nowrap={this.props.truncate}
+        onClick={() => { this._onClick() }}
+      >
 
         {this.state.message}
 
@@ -211,6 +220,12 @@ Text.propTypes = {
    * @uxpindescription Specify a text color with a Hex or color token, such as '#ffffff'. 
    */
   color: PropTypes.string,
+
+  /**
+   * @uxpindescription Fires when the control is clicked on
+   * @uxpinpropname Click
+   */
+  onClickText: PropTypes.func,
 };
 
 

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -123,13 +123,6 @@ class Text extends React.Component {
     </span >)
   }
 
-  _onClick() {
-    //Raise this event to UXPin. 
-    if (this.props.onClickText) {
-      this.props.onClickText(true);
-    }
-  }
-
   render() {
     //Let's see if the user entered a valid color value. This method returns undefined if not. 
     let textColor = UxpColors.getHexFromHexOrToken(this.props.color);
@@ -153,7 +146,6 @@ class Text extends React.Component {
         styles={fTextStyles}
         variant={this.props.size}
         nowrap={this.props.truncate}
-        onClick={() => { this._onClick() }}
       >
 
         {this.state.message}
@@ -220,12 +212,6 @@ Text.propTypes = {
    * @uxpindescription Specify a text color with a Hex or color token, such as '#ffffff'. 
    */
   color: PropTypes.string,
-
-  /**
-   * @uxpindescription Fires when the control is clicked on
-   * @uxpinpropname Click
-   */
-  onClickText: PropTypes.func,
 };
 
 


### PR DESCRIPTION
Added the Callout control. This control can optionally have a "focus" control, and can host additional Merge children as extra UI elements. 

TeachingBubble, Coachmark
Added the feature for these controls to support a "focus" control. Now they can also host additional Merge children as extra UI elements. Both also support the extra wide prop. 

Tooltip
Minor UI updates