### PR TITLE
Various Updates: Nav, Facepile, Timestamp, StatusSet

### DIFF
--- a/src/components/Facepile/Facepile.js
+++ b/src/components/Facepile/Facepile.js
@@ -247,7 +247,6 @@ class Facepile extends React.Component {
             maxHeight: '410px',
         };
 
-
         return (
             <>
                 <FFacepile

--- a/src/components/Facepile/Facepile.js
+++ b/src/components/Facepile/Facepile.js
@@ -266,24 +266,26 @@ class Facepile extends React.Component {
                         className={styles.callout}
                         onDismiss={() => { this._onDismissCallout() }}
                     >
-                        {
-                            this.state.personaList.slice(this.props.faceCount).map((anObjectMapped, index) => {
-                                return (
-                                    <Persona
-                                        key={anObjectMapped.key}
-                                        presence={this.props.showPresence ? anObjectMapped.presence : 0}
-                                        hidePersonaDetails={false}
-                                        size={PersonaSize["size40"]}
-                                        imageUrl={anObjectMapped.imageUrl}
-                                        imageInitials={anObjectMapped.imageInitials}
-                                        initialsColor={anObjectMapped.initialsColor}
-                                        text={anObjectMapped.text}
-                                        secondaryText={this._getLinkedEmail(anObjectMapped)}
-                                        className={styles.overflowItems}
-                                    />
-                                );
-                            })
-                        }
+                        <div style="overflowX: hidden; overflowY: auto;">
+                            {
+                                this.state.personaList.slice(this.props.faceCount).map((anObjectMapped, index) => {
+                                    return (
+                                        <Persona
+                                            key={anObjectMapped.key}
+                                            presence={this.props.showPresence ? anObjectMapped.presence : 0}
+                                            hidePersonaDetails={false}
+                                            size={PersonaSize["size40"]}
+                                            imageUrl={anObjectMapped.imageUrl}
+                                            imageInitials={anObjectMapped.imageInitials}
+                                            initialsColor={anObjectMapped.initialsColor}
+                                            text={anObjectMapped.text}
+                                            secondaryText={this._getLinkedEmail(anObjectMapped)}
+                                            className={styles.overflowItems}
+                                        />
+                                    );
+                                })
+                            }
+                        </div>
                     </Callout>
                     : null}
             </>

--- a/src/components/Facepile/Facepile.js
+++ b/src/components/Facepile/Facepile.js
@@ -244,7 +244,7 @@ class Facepile extends React.Component {
         const overflowStyle = {
             overflowX: 'hidden',
             overflowY: 'auto',
-            maxHeight: '310px',
+            maxHeight: '410px',
         };
 
 

--- a/src/components/Facepile/Facepile.js
+++ b/src/components/Facepile/Facepile.js
@@ -244,7 +244,7 @@ class Facepile extends React.Component {
         const overflowStyle = {
             overflowX: 'hidden',
             overflowY: 'auto',
-            maxHeight: '300px',
+            maxHeight: '310px',
         };
 
 

--- a/src/components/Facepile/Facepile.js
+++ b/src/components/Facepile/Facepile.js
@@ -266,7 +266,7 @@ class Facepile extends React.Component {
                         className={styles.callout}
                         onDismiss={() => { this._onDismissCallout() }}
                     >
-                        <div style="overflowX: hidden; overflowY: auto;">
+                        <div style={{ overflowX: 'hidden', overflowY: 'auto' }}>
                             {
                                 this.state.personaList.slice(this.props.faceCount).map((anObjectMapped, index) => {
                                     return (

--- a/src/components/Facepile/Facepile.js
+++ b/src/components/Facepile/Facepile.js
@@ -244,6 +244,7 @@ class Facepile extends React.Component {
         const overflowStyle = {
             overflowX: 'hidden',
             overflowY: 'auto',
+            maxHeight: '300px',
         };
 
 

--- a/src/components/Facepile/Facepile.js
+++ b/src/components/Facepile/Facepile.js
@@ -241,6 +241,11 @@ class Facepile extends React.Component {
             onClick: ((e) => this._onClickAddButton(e))
         };
 
+        const overflowStyle = {
+            overflowX: 'hidden',
+            overflowY: 'auto',
+        };
+
 
         return (
             <>
@@ -266,7 +271,7 @@ class Facepile extends React.Component {
                         className={styles.callout}
                         onDismiss={() => { this._onDismissCallout() }}
                     >
-                        <div style={{ overflowX: 'hidden', overflowY: 'auto' }}>
+                        <div style={overflowStyle}>
                             {
                                 this.state.personaList.slice(this.props.faceCount).map((anObjectMapped, index) => {
                                     return (

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -159,7 +159,7 @@ Image.propTypes = {
 Image.defaultProps = {
     imageToken: defaultImageToken,
     imageUrl: '',
-    imageFit: fitContain,
+    imageFit: fitCenterCover,
     imgWidth: 200,
     imgHeight: 200,
 }

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -133,7 +133,7 @@ Link.propTypes = {
  */
 Link.defaultProps = {
     value: 'UXPin.com',
-    linkHref: 'https://www.uxpin.com',
+    linkHref: '',
     size: 'medium',
     bold: false,
     italic: false,

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -272,7 +272,7 @@ Nav.defaultProps = {
     navTopPadding: defaultTopPadding,
     selectedIndex: 1,
     items: defaultNavItems,
-    styledBackground: false,
+    styledBackground: true,
     disabled: '',
 };
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -36,18 +36,9 @@ class Nav extends React.Component {
     set() {
         let disabledItems = UxpNumberParser.parseInts(this.props.disabled);
 
-        var items = UXPinParser.parse(this.props.items).map(
-            (item, index) => ({
-                key: index + 1,
-                name: item.text ? item.text : '',
-                icon: item?.iconName,
-                disabled: disabledItems.includes(index + 1),
-            }));
-
-        //Trying parser next
+        var items = [];
         if (this.props.items) {
-            let parsedNavItemText = UxpMenuUtils.parseNavItemText(this.props.items, this.props.selectedIndex, disabledItems, true);
-            items = parsedNavItemText;
+            items = UxpMenuUtils.parseNavItemText(this.props.items, this.props.selectedIndex, disabledItems, true);
         }
 
         this.setState({
@@ -62,10 +53,10 @@ class Nav extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.selectedIndex !== this.props.selectedIndex) {
-            this.setState(
-                { selectedIndex: this.props.selectedIndex }
-            )
+        if (prevProps.selectedIndex !== this.props.selectedIndex ||
+            prevProps.items !== this.props.items ||
+            prevProps.disabled !== this.props.disabled) {
+            this.set();
         }
 
         //The disabled indexes and items are set in one call

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -155,7 +155,7 @@ Nav.propTypes = {
     selectedIndex: PropTypes.number,
 
     /**
-     * @uxpindescription The list of nav items. Put each item on a separate line. Specify an icon using: icon(IconName) Nav Text. For a second level child nav item, start the line with a star: * icon(IconName) Child Item. 
+     * @uxpindescription The list of nav items. Put each item on a separate line. Specify an icon using: icon(IconName) Nav Text. For a second level child nav item, start the line with a star: * icon(IconName) Child Item
      * @uxpinpropname Items
      * @uxpincontroltype codeeditor
      */

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -36,7 +36,7 @@ class Nav extends React.Component {
     set() {
         let disabledItems = UxpNumberParser.parseInts(this.props.disabled);
 
-        let items = UXPinParser.parse(this.props.items).map(
+        var items = UXPinParser.parse(this.props.items).map(
             (item, index) => ({
                 key: index + 1,
                 name: item.text ? item.text : '',
@@ -47,6 +47,7 @@ class Nav extends React.Component {
         //Trying parser next
         if (this.props.items) {
             let parsedNavItemText = UxpMenuUtils.parseNavItemText(this.props.items, true);
+            items = parseNavItemText;
             console.log('Parsed JSON for Nav control: ' + JSON.stringify(parsedNavItemText));
         }
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -46,7 +46,7 @@ class Nav extends React.Component {
 
         //Trying parser next
         if (this.props.items) {
-            let parsedNavItemText = UxpMenuUtils.parseNavItemText(this.props.items, true);
+            let parsedNavItemText = UxpMenuUtils.parseNavItemText(this.props.items, disabledItems, true);
             items = parsedNavItemText;
             console.log('Parsed JSON for Nav control: ' + JSON.stringify(parsedNavItemText));
         }

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -271,7 +271,7 @@ Nav.defaultProps = {
     navTopPadding: defaultTopPadding,
     selectedIndex: 1,
     items: defaultNavItems,
-    styledBackground: true,
+    styledBackground: false,
     disabled: '',
 };
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -47,7 +47,7 @@ class Nav extends React.Component {
         //Trying parser next
         if (this.props.items) {
             let parsedNavItemText = UxpMenuUtils.parseNavItemText(this.props.items, true);
-            items = parseNavItemText;
+            items = parsedNavItemText;
             console.log('Parsed JSON for Nav control: ' + JSON.stringify(parsedNavItemText));
         }
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -46,9 +46,8 @@ class Nav extends React.Component {
 
         //Trying parser next
         if (this.props.items) {
-            let parsedNavItemText = UxpMenuUtils.parseNavItemText(this.props.items, disabledItems, true);
+            let parsedNavItemText = UxpMenuUtils.parseNavItemText(this.props.items, this.props.selectedIndex, disabledItems, true);
             items = parsedNavItemText;
-            console.log('Parsed JSON for Nav control: ' + JSON.stringify(parsedNavItemText));
         }
 
         this.setState({

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { Nav as FNav } from '@fluentui/react/lib/Nav';
 import { UxpNumberParser } from '../_helpers/uxpnumberparser';
-import * as UXPinParser from '../_helpers/UXPinParser';
 import { UxpMenuUtils } from '../_helpers/uxpmenuutils';
 
 

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -155,7 +155,7 @@ Nav.propTypes = {
     selectedIndex: PropTypes.number,
 
     /**
-     * @uxpindescription The list of nav items. Put each item on a separate line. Specify an icon using: icon(IconName)
+     * @uxpindescription The list of nav items. Put each item on a separate line. Specify an icon using: icon(IconName) Nav Text. For a second level child nav item, start the line with a star: * icon(IconName) Child Item. 
      * @uxpinpropname Items
      * @uxpincontroltype codeeditor
      */

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -20,8 +20,7 @@ const stackItemStyles = {
 const stackTokens = {
     childrenGap: '6px',
     padding: 12,
-
-    background: 'purple',
+    background: '#800080',
 };
 
 //For the Persona

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -21,6 +21,7 @@ const stackTokens = {
     childrenGap: '6px',
     padding: 12,
     background: '#800080',
+    midWidth: '300px',
 };
 
 //For the Persona
@@ -32,10 +33,9 @@ const personaStyles = {
 };
 
 //This is the default URL to use for a generic female user
-const defaultPersonaUrl = "https://raw.githubusercontent.com/uxpin-merge/fluent-ui-uxpin-merge/master/src/components/_helpers/_images/person04.jpg";
 const defaultSize = 'size72';
-const cmdBarHAlign = 'left';
-const cmdBarVAlign = 'middle';
+const cmdBarHAlign = 'start';
+const cmdBarVAlign = 'center';
 
 
 
@@ -84,13 +84,12 @@ class ProfileCard extends React.Component {
             };
 
             commandBar = (
-
                 <Stack
                     tokens={cbarStackTokens}
                     styles={cbarStackItemStyles}
                     horizontal={true}
-                    horizontalAlign={'start'}
-                    verticalAlign={'center'}
+                    horizontalAlign={cmdBarHAlign}
+                    verticalAlign={cmdBarVAlign}
                 >
                     {childList}
                 </Stack >

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -100,6 +100,7 @@ class ProfileCard extends React.Component {
                     root: {
                         minWidth: '300px',
                         background: '#333',
+                        paddingBottom: '0',
                     }
                 }}>
                 <StackItem>

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -75,6 +75,7 @@ class ProfileCard extends React.Component {
             const cbarStackTokens = {
                 childrenGap: 6,
                 padding: 0,
+                background: 'purple',
             };
 
             const cbarStackItemStyles = {

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -15,13 +15,13 @@ const stackItemStyles = {
     root: {
         height: 'auto',
         width: 'auto',
+        midWidth: '300px',
     },
 };
 const stackTokens = {
     childrenGap: '6px',
     padding: 12,
     background: '#800080',
-    midWidth: '300px',
 };
 
 //For the Persona
@@ -103,8 +103,7 @@ class ProfileCard extends React.Component {
                 horizontal={false}
                 horizontalAlign={stackHAlign}
                 verticalAlign={stackVAlign}
-                wrap={false}
-                styles={stackItemStyles} >
+                wrap={false}>
 
                 <Persona
                     size={PersonaSize[this.props.ppSize]}
@@ -120,7 +119,6 @@ class ProfileCard extends React.Component {
                     styles={personaStyles}
                 >
                     {email}
-                    {"Hello!"}
                 </Persona>
 
                 {commandBar}

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -28,7 +28,7 @@ const personaStyles = {
 const defaultSize = 'size72';
 const cmdBarHAlign = 'start';
 const cmdBarVAlign = 'center';
-
+const cardMinWidth = '325px';
 
 
 class ProfileCard extends React.Component {
@@ -98,7 +98,7 @@ class ProfileCard extends React.Component {
                 wrap={false}
                 styles={{
                     root: {
-                        minWidth: '300px',
+                        minWidth: cardMinWidth,
                         paddingBottom: '0',
                     }
                 }}>

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -20,6 +20,8 @@ const stackItemStyles = {
 const stackTokens = {
     childrenGap: '6px',
     padding: 12,
+
+    background: 'purple',
 };
 
 //For the Persona
@@ -75,7 +77,6 @@ class ProfileCard extends React.Component {
             const cbarStackTokens = {
                 childrenGap: 6,
                 padding: 0,
-                background: 'purple',
             };
 
             const cbarStackItemStyles = {
@@ -86,8 +87,7 @@ class ProfileCard extends React.Component {
 
             commandBar = (
 
-                < Stack
-                    {...this.props}
+                <Stack
                     tokens={cbarStackTokens}
                     styles={cbarStackItemStyles}
                     horizontal={true}

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -99,7 +99,6 @@ class ProfileCard extends React.Component {
                 styles={{
                     root: {
                         minWidth: '300px',
-                        background: '#333',
                         paddingBottom: '0',
                     }
                 }}>

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -9,7 +9,7 @@ import { UxpPersonaData } from '../_helpers/uxppersonadata';
 
 
 //For the Stack
-const stackVAlign = 'start';
+const stackVAlign = 'center';
 const stackHAlign = 'stretch';
 const stackItemStyles = {
     root: {
@@ -72,12 +72,12 @@ class ProfileCard extends React.Component {
             //First, let's create our own array of children, since UXPin returns an object for 1 child, or an array for 2 or more.
             let childList = React.Children.toArray(this.props.children);
 
-            const stackTokens = {
+            const cbarStackTokens = {
                 childrenGap: 6,
                 padding: 0,
             };
 
-            const stackItemStyles = {
+            const cbarStackItemStyles = {
                 root: {
                     height: 'auto',
                 },
@@ -87,11 +87,11 @@ class ProfileCard extends React.Component {
 
                 < Stack
                     {...this.props}
-                    tokens={stackTokens}
-                    styles={stackItemStyles}
+                    tokens={cbarStackTokens}
+                    styles={cbarStackItemStyles}
                     horizontal={true}
                     horizontalAlign={'start'}
-                    verticalAlign={'middle'}
+                    verticalAlign={'center'}
                 >
                     {childList}
                 </Stack >

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -99,7 +99,6 @@ class ProfileCard extends React.Component {
         return (
 
             <Stack
-                {...this.props}
                 tokens={stackTokens}
                 horizontal={false}
                 horizontalAlign={stackHAlign}
@@ -108,7 +107,6 @@ class ProfileCard extends React.Component {
                 styles={stackItemStyles} >
 
                 <Persona
-                    {...this.props}
                     size={PersonaSize[this.props.ppSize]}
                     imageUrl={imgURL}
                     imageInitials={this.props.initials}

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -60,7 +60,6 @@ class ProfileCard extends React.Component {
 
             email = (
                 <Link
-                    // {...this.props}
                     value={this.props.email}
                     href={link ? link : ''}
                     bold={false}
@@ -125,6 +124,7 @@ class ProfileCard extends React.Component {
                     styles={personaStyles}
                 >
                     {email}
+                    {"Hello!"}
                 </Persona>
 
                 {commandBar}

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import Link from '../Link/Link';
 import { Persona, PersonaSize } from '@fluentui/react/lib/Persona';
-import { Stack } from '@fluentui/react/lib/Stack';
+import { Stack, StackItem } from '@fluentui/react/lib/Stack';
 import { UxpImageUtils } from '../_helpers/uxpimageutils';
 import { UxpPersonaData } from '../_helpers/uxppersonadata';
 
@@ -11,17 +11,9 @@ import { UxpPersonaData } from '../_helpers/uxppersonadata';
 //For the Stack
 const stackVAlign = 'center';
 const stackHAlign = 'stretch';
-const stackItemStyles = {
-    root: {
-        height: 'auto',
-        width: 'auto',
-        midWidth: '300px',
-    },
-};
 const stackTokens = {
     childrenGap: '6px',
     padding: 12,
-    background: '#800080',
 };
 
 //For the Persona
@@ -99,31 +91,38 @@ class ProfileCard extends React.Component {
         return (
 
             <Stack
-                //tokens={stackTokens}
+                tokens={stackTokens}
                 horizontal={false}
                 horizontalAlign={stackHAlign}
                 verticalAlign={stackVAlign}
-                wrap={false}>
+                wrap={false}
+                styles={{
+                    root: {
+                        minWidth: '300px',
+                        background: '#333',
+                    }
+                }}>
+                <StackItem>
+                    <Persona
+                        size={PersonaSize[this.props.ppSize]}
+                        imageUrl={imgURL}
+                        imageInitials={this.props.initials}
+                        presence={presenceCode}
+                        initialsColor={this.props.ppInitialsColor}
+                        text={this.props.name}
+                        secondaryText={this.props.role}
+                        tertiaryText={this.props.status}
+                        optionalText={this.props.optional}
+                        children={undefined}
+                        styles={personaStyles}
+                    >
+                        {email}
+                    </Persona>
 
-                <Persona
-                    size={PersonaSize[this.props.ppSize]}
-                    imageUrl={imgURL}
-                    imageInitials={this.props.initials}
-                    presence={presenceCode}
-                    initialsColor={this.props.ppInitialsColor}
-                    text={this.props.name}
-                    secondaryText={this.props.role}
-                    tertiaryText={this.props.status}
-                    optionalText={this.props.optional}
-                    children={undefined}
-                    styles={personaStyles}
-                >
-                    {email}
-                </Persona>
-
-                {commandBar}
-
+                    {commandBar}
+                </StackItem>
             </Stack>
+
         );
     }
 }

--- a/src/components/ProfileCard/ProfileCard.js
+++ b/src/components/ProfileCard/ProfileCard.js
@@ -99,7 +99,7 @@ class ProfileCard extends React.Component {
         return (
 
             <Stack
-                tokens={stackTokens}
+                //tokens={stackTokens}
                 horizontal={false}
                 horizontalAlign={stackHAlign}
                 verticalAlign={stackVAlign}

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -102,6 +102,12 @@ class SearchBox extends React.Component {
 SearchBox.propTypes = {
 
   /**
+   * @uxpindescription The exact name from the icon library. Displays on the right side. 
+   * @uxpinpropname Icon Name
+   * */
+  icon: PropTypes.string,
+
+  /**
    * We give this property a unique name to avoid collisions. We map its value to the control's 'value' prop.
    * @uxpindescription Current value of the text field. This prop's live value is available for scripting.
    * @uxpinpropname * Value
@@ -115,12 +121,6 @@ SearchBox.propTypes = {
    * @uxpinpropname Placeholder
    * */
   placeholder: PropTypes.string,
-
-  /**
-   * @uxpindescription The exact name from the PayPal icon library. Displays on the right side. 
-   * @uxpinpropname Icon Name
-   * */
-  icon: PropTypes.string,
 
   /**
    * @uxpindescription To disable the control

--- a/src/components/StatusSet/StatusSet.js
+++ b/src/components/StatusSet/StatusSet.js
@@ -20,7 +20,11 @@ const posEnd = 'end';
 const statusDefault = 'info';
 const statusCustom = 'custom';
 const statusList = [
-   'info', 'success', 'done', 'ok', 'good', 'ready', 'warning', 'error', 'failed', 'skipped', 'unknown', 'blocked', 'syncing', 'inProgress', 'queued', 'waiting', 'currentStep', 'futureStep', 'reverted', 'restored', statusCustom
+   'info', 'success', 'done', 'ok', 'good', 'ready',
+   'passed', 'completed', 'approved',
+   'warning', 'error', 'failed', 'offline',
+   'pending', 'validating',
+   'skipped', 'unknown', 'blocked', 'syncing', 'inProgress', 'queued', 'waiting', 'currentStep', 'futureStep', 'scheduled', 'reverted', 'restored', 'statusCustom'
 ];
 const iconSizeMap = {
    tiny: 10,
@@ -162,7 +166,7 @@ class StatusSet extends React.Component {
                   internalPadding={0}
                   gutterPadding={this.props.gutterPadding}
                   align={'stretch'}
-                  vAlign={'middle'}
+                  vAlign={'center'}
                   addSpanner={false}
                   wrap={false}
                   bgColor={''}

--- a/src/components/StatusSet/StatusSet.js
+++ b/src/components/StatusSet/StatusSet.js
@@ -20,11 +20,7 @@ const posEnd = 'end';
 const statusDefault = 'info';
 const statusCustom = 'custom';
 const statusList = [
-   'info', 'success', 'done', 'ok', 'good', 'ready',
-   'passed', 'completed', 'approved',
-   'warning', 'error', 'failed', 'offline',
-   'pending', 'validating',
-   'skipped', 'unknown', 'blocked', 'syncing', 'inProgress', 'queued', 'waiting', 'currentStep', 'futureStep', 'scheduled', 'reverted', 'restored', 'statusCustom'
+   'info', 'success', 'done', 'ok', 'good', 'ready', 'passed', 'completed', 'approved', 'warning', 'error', 'failed', 'offline', 'pending', 'validating', 'skipped', 'unknown', 'blocked', 'syncing', 'inProgress', 'queued', 'waiting', 'currentStep', 'futureStep', 'scheduled', 'reverted', 'restored', statusCustom
 ];
 const iconSizeMap = {
    tiny: 10,

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -89,6 +89,7 @@ class Timestamp extends React.Component {
                   value={linkText}
                   linkHref={''}
                   italic={this.props.italic}
+                  align={this.props.align}
                   id={ttTargetID}
                   aria-describedby={tooltipID}
                />

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -101,6 +101,7 @@ class Timestamp extends React.Component {
                   horizontal={true}
                   horizontalAlign={stretchAlign}
                   verticalAlign={middleAlign}
+                  style={{ width: '100%' }}
                >
                   <Link
                      {...this.props}
@@ -109,7 +110,6 @@ class Timestamp extends React.Component {
                      align={this.props.align}
                      id={ttTargetID}
                      aria-describedby={tooltipID}
-                     style={{ width: '100%' }}
                   />
                </Stack>
             </TooltipHost>

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import Link from '../Link/Link';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
-import { Stack } from '@fluentui/react/lib/Stack';
+import { Stack, StackItem } from '@fluentui/react/lib/Stack';
 import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 import { UxpDateTimeUtils } from '../_helpers/uxpdatetimeutils';
 
@@ -13,6 +13,8 @@ const centerAlign = 'center';
 const rightAlign = 'right';
 const stretchAlign = 'stretch';
 const middleAlign = 'middle';
+const startAlign = 'start';
+const endAlign = 'end';
 
 class Timestamp extends React.Component {
 
@@ -89,8 +91,8 @@ class Timestamp extends React.Component {
          },
       };
 
-      let hAlign = this.props.align === leftAlign ? leftAlign :
-         this.props.align === rightAlign ? rightAlign :
+      let hAlign = this.props.align === startAlign ? leftAlign :
+         this.props.align === endAlign ? rightAlign :
             this.props.align === centerAlign ? centerAlign :
                stretchAlign;
 
@@ -111,14 +113,17 @@ class Timestamp extends React.Component {
                   verticalAlign={middleAlign}
                   styles={topStackItemStyles}
                >
-                  <Link
-                     {...this.props}
-                     value={linkText}
-                     linkHref={''}
-                     align={this.props.align}
-                     id={ttTargetID}
-                     aria-describedby={tooltipID}
-                  />
+                  <StackItem
+                     horizontalAlign={hAlign}>
+                     <Link
+                        {...this.props}
+                        value={linkText}
+                        linkHref={''}
+                        align={this.props.align}
+                        id={ttTargetID}
+                        aria-describedby={tooltipID}
+                     />
+                  </StackItem>
                </Stack>
             </TooltipHost>
          </>

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -85,7 +85,6 @@ class Timestamp extends React.Component {
 
       const topStackItemStyles = {
          root: {
-            background: 'purple',        //undefined is OK
             height: 'auto',
             width: '100%',
          },
@@ -95,8 +94,6 @@ class Timestamp extends React.Component {
          this.props.align === rightAlign ? endAlign :
             this.props.align === centerAlign ? centerAlign :
                stretchAlign;
-
-      console.log("hAlign: " + hAlign);
 
       return (
          <>
@@ -114,8 +111,7 @@ class Timestamp extends React.Component {
                   verticalAlign={middleAlign}
                   styles={topStackItemStyles}
                >
-                  <StackItem
-                     horizontalAlign={hAlign}>
+                  <StackItem>
                      <Link
                         {...this.props}
                         value={linkText}

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -2,11 +2,17 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import Link from '../Link/Link';
 import { DirectionalHint } from '@fluentui/react/lib/Callout';
+import { Stack } from '@fluentui/react/lib/Stack';
 import { TooltipHost } from '@fluentui/react/lib/Tooltip';
 import { UxpDateTimeUtils } from '../_helpers/uxpdatetimeutils';
 
 
 
+const leftAlign = 'left';
+const centerAlign = 'center';
+const rightAlign = 'right';
+const stretchAlign = 'stretch';
+const middleAlign = 'middle';
 
 class Timestamp extends React.Component {
 
@@ -75,7 +81,11 @@ class Timestamp extends React.Component {
          target: `#${ttTargetID}`,
       };
 
-      console.log("align: " + this.props.align);
+      let hAlign = this.props.align === leftAlign ? leftAlign :
+         this.props.align === rightAlign ? rightAlign :
+            this.props.align === centerAlign ? centerAlign :
+               stretchAlign;
+
 
       return (
          <>
@@ -86,15 +96,22 @@ class Timestamp extends React.Component {
                closeDelay={500}
                calloutProps={ttProps}
             >
-               <Link
-                  {...this.props}
-                  value={linkText}
-                  linkHref={''}
-                  align={this.props.align}
-                  id={ttTargetID}
-                  aria-describedby={tooltipID}
-                  style={{ width: '100%' }}
-               />
+               <Stack
+                  padding={0}
+                  horizontal={true}
+                  horizontalAlign={hAlign}
+                  verticalAlign={middleAlign}
+               >
+                  <Link
+                     {...this.props}
+                     value={linkText}
+                     linkHref={''}
+                     align={this.props.align}
+                     id={ttTargetID}
+                     aria-describedby={tooltipID}
+                     style={{ width: '100%' }}
+                  />
+               </Stack>
             </TooltipHost>
          </>
       );
@@ -150,7 +167,7 @@ Timestamp.propTypes = {
    /**
    * @uxpindescription Text alignment
    */
-   align: PropTypes.oneOf(['left', 'center', 'right']),
+   align: PropTypes.oneOf([leftAlign, centerAlign, rightAlign]),
 
    /**
     * @uxpindescription The display size, corresponding to a Microsoft Text 'Variant'
@@ -180,7 +197,7 @@ Timestamp.defaultProps = {
    showTime: true,
    showSeconds: false,
    is24: false,
-   align: 'left',
+   align: leftAlign,
    size: 'medium',
    bold: false,
    italic: false,

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -96,6 +96,7 @@ class Timestamp extends React.Component {
             this.props.align === centerAlign ? centerAlign :
                stretchAlign;
 
+      console.log("hAlign: " + hAlign);
 
       return (
          <>
@@ -109,7 +110,7 @@ class Timestamp extends React.Component {
                <Stack
                   padding={0}
                   horizontal={true}
-                  horizontalAlign={stretchAlign}
+                  horizontalAlign={stretchAlignhAlign}
                   verticalAlign={middleAlign}
                   styles={topStackItemStyles}
                >

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -75,6 +75,12 @@ class Timestamp extends React.Component {
          target: `#${ttTargetID}`,
       };
 
+      let linkTextStyles = {
+         root: {
+            textAlign: this.props.align,
+         }
+      };
+
       return (
          <>
             <TooltipHost
@@ -88,8 +94,7 @@ class Timestamp extends React.Component {
                   {...this.props}
                   value={linkText}
                   linkHref={''}
-                  italic={this.props.italic}
-                  align={this.props.align}
+                  styles={linkTextStyles}
                   id={ttTargetID}
                   aria-describedby={tooltipID}
                />

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -75,11 +75,7 @@ class Timestamp extends React.Component {
          target: `#${ttTargetID}`,
       };
 
-      let linkTextStyles = {
-         root: {
-            textAlign: this.props.align,
-         }
-      };
+      console.log("align: " + this.props.align);
 
       return (
          <>
@@ -94,7 +90,7 @@ class Timestamp extends React.Component {
                   {...this.props}
                   value={linkText}
                   linkHref={''}
-                  styles={linkTextStyles}
+                  align={this.props.align}
                   id={ttTargetID}
                   aria-describedby={tooltipID}
                />

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -81,6 +81,14 @@ class Timestamp extends React.Component {
          target: `#${ttTargetID}`,
       };
 
+      const topStackItemStyles = {
+         root: {
+            background: 'purple',        //undefined is OK
+            height: 'auto',
+            width: '100%',
+         },
+      };
+
       let hAlign = this.props.align === leftAlign ? leftAlign :
          this.props.align === rightAlign ? rightAlign :
             this.props.align === centerAlign ? centerAlign :
@@ -101,7 +109,7 @@ class Timestamp extends React.Component {
                   horizontal={true}
                   horizontalAlign={stretchAlign}
                   verticalAlign={middleAlign}
-                  style={{ width: '100%' }}
+                  styles={topStackItemStyles}
                >
                   <Link
                      {...this.props}

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -12,7 +12,7 @@ const leftAlign = 'left';
 const centerAlign = 'center';
 const rightAlign = 'right';
 const stretchAlign = 'stretch';
-const middleAlign = 'middle';
+const middleAlign = 'center';
 const startAlign = 'start';
 const endAlign = 'end';
 

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -91,8 +91,8 @@ class Timestamp extends React.Component {
          },
       };
 
-      let hAlign = this.props.align === startAlign ? leftAlign :
-         this.props.align === endAlign ? rightAlign :
+      let hAlign = this.props.align === leftAlign ? startAlign :
+         this.props.align === rightAlign ? endAlign :
             this.props.align === centerAlign ? centerAlign :
                stretchAlign;
 
@@ -110,7 +110,7 @@ class Timestamp extends React.Component {
                <Stack
                   padding={0}
                   horizontal={true}
-                  horizontalAlign={stretchAlignhAlign}
+                  horizontalAlign={hAlign}
                   verticalAlign={middleAlign}
                   styles={topStackItemStyles}
                >

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -93,6 +93,7 @@ class Timestamp extends React.Component {
                   align={this.props.align}
                   id={ttTargetID}
                   aria-describedby={tooltipID}
+                  style={{ width: '100%' }}
                />
             </TooltipHost>
          </>

--- a/src/components/Timestamp/Timestamp.js
+++ b/src/components/Timestamp/Timestamp.js
@@ -99,7 +99,7 @@ class Timestamp extends React.Component {
                <Stack
                   padding={0}
                   horizontal={true}
-                  horizontalAlign={hAlign}
+                  horizontalAlign={stretchAlign}
                   verticalAlign={middleAlign}
                >
                   <Link

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -313,7 +313,7 @@ export const UxpMenuUtils = {
    getNavItemProps: function (index, text, iconName, isExpanded, disabled) {
       let navProps = {
          key: index + 1,
-         text: text ? text : '',
+         name: text ? text : '',
          icon: iconName ? iconName : '',
          isExpanded: isExpanded,
          disabled: disabled,

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -186,15 +186,9 @@ export const UxpMenuUtils = {
       var propsList = [];
 
       if (rawPropText) {
-
-         console.log("parseNavItemText > Entering parser... " + rawPropText);
-
-
          //Split each line out.
          let items = rawPropText.match(/[^\r\n]+/g);
          let hasChildren = allowChildren ? this.testForChildren(rawPropText) : false;
-
-         console.log("parseNavItemText > hasChildren " + hasChildren);
 
          //The first item must be a regular nav item.
          var i;
@@ -216,16 +210,12 @@ export const UxpMenuUtils = {
                hasChild = this.isChildItem(items, i + 1);
             }
 
-            console.log("     > isChild " + isChild);
-
             //Parse the individual item. It may have an icon.
             let parsedNavItems = UXPinParser.parse(item);
 
             if (parsedNavItems && parsedNavItems.length > 0) {
                let parsedItem = parsedNavItems[0];
                let trimmedText = parsedItem?.text?.trim();
-
-               console.log("     > trimmedText " + trimmedText);
 
                if (parsedItem && trimmedText) {
                   let iconName = hasChild ? undefined : parsedItem?.iconName;
@@ -235,18 +225,13 @@ export const UxpMenuUtils = {
                   if (props) {
 
                      if (isChild) {
-                        console.log("    > propslist length: " + propsList.length);
                         let parent = propsList[propsList.length - 1];
-
-                        console.log("    > this is the parent: " + parent.text);
-                        console.log("    > its child: " + props.text);
 
                         this.appendNavItemChildProps(parent, props);
 
-                        console.log("    > After appending the child: " + parent.links);
+                        console.log("    > After appending the child: " + JSON.stringify(parent));
                      }
                      else {
-                        console.log("pushing props to the propsList for: " + props.text);
                         propsList.push(props);
                      }
                   }
@@ -326,13 +311,8 @@ export const UxpMenuUtils = {
     * @returns {string} Returns a JSON props object representing a generic Nav item. 
     */
    getNavItemProps: function (index, text, iconName, isExpanded, disabled) {
-      let key = index + 1;
-
-      console.log("Entering getNavItemProps for " + text);
-      //this.getNavItemProps(i, trimmedText, iconName, false, false);
-
       let navProps = {
-         key: key,
+         key: index + 1,
          text: text ? text : '',
          icon: iconName ? iconName : '',
          isExpanded: isExpanded,
@@ -347,9 +327,6 @@ export const UxpMenuUtils = {
          return false;
 
       parentItem.links = parentItem.links.concat(childItem);
-
-      console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
-
       return true;
    }
 

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -240,6 +240,9 @@ export const UxpMenuUtils = {
 
                         console.log("    > this is the parent: " + parent.text);
                         console.log("    > its child: " + props.text);
+
+                        this.appendNavItemChildProps(parent, props);
+
                         console.log("    > After appending the child: " + parent.links);
                      }
                      else {
@@ -340,21 +343,21 @@ export const UxpMenuUtils = {
    },
 
    appendNavItemChildProps: function (parentItem, childItem) {
-      if (parentItem && childItem) {
-
-         console.log("append > child item: " + childItem);
-         console.log("       > Parent's original props: " + JSON.stringify(parentItem));
-
-         let links = {
-            links: { childItem },
-         };
 
 
-         parentItem.links = links;
+      console.log("append > child item: " + childItem);
+      console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-         console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
-         return links;
-      }
+      let links = {
+         links: { childItem },
+      };
+
+
+      parentItem.links = links;
+
+      console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
+      return links;
+
    }
 
 };

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -348,7 +348,8 @@ export const UxpMenuUtils = {
       console.log("append > child item: " + childItem);
       console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-      parentItem.links = { ...parentItem.links, ...childItem };
+      let plinks = parentItem.links;
+      parentItem.links = [{ ...plinks, ...childItem }];
 
       console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
       return true;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -348,11 +348,7 @@ export const UxpMenuUtils = {
       console.log("append > child item: " + childItem);
       console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-      var plinks = childItem;
-
-      if (parentItem.links && parentItem.links?.length > 0) {
-         plinks = parentItem.links.concat(childItem);
-      }
+      let plinks = parentItem.links.concat(childItem);
 
       console.log("       > plinks: " + JSON.stringify(plinks));
 

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -349,7 +349,7 @@ export const UxpMenuUtils = {
       console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
       let plinks = parentItem.links;
-      parentItem.links = [{ ...plinks, ...childItem }];
+      parentItem.links = [{ ...plinks, childItem }];
 
       console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
       return true;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -226,6 +226,8 @@ export const UxpMenuUtils = {
                   //If the index is for a parent or one of its children, expand the parent.
                   let expanded = selectedIndex === i + 1 ? true : false;
 
+                  console.log("      > isExpanded: " + expanded + " for " + i);
+
                   let props = this.getNavItemProps(i, trimmedText, iconName, expanded, disabled);
 
                   //OK! If this is a child item, append it to the last item in the props array. If it's not, push it to the props array.
@@ -235,6 +237,8 @@ export const UxpMenuUtils = {
                         let parent = propsList[propsList.length - 1];
                         this.appendNavItemChildProps(parent, props);
                         parent.isExpanded = expanded;
+
+                        console.log("      > parent.isExpanded: " + parent.isExpanded + " for " + parent.name);
                      }
                      else {
                         propsList.push(props);

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -236,7 +236,9 @@ export const UxpMenuUtils = {
                      if (isChild) {
                         let parent = propsList[propsList.length - 1];
                         this.appendNavItemChildProps(parent, props);
-                        parent.isExpanded = expanded;
+
+                        if (expanded)
+                           parent.isExpanded = expanded;
 
                         console.log("      > parent.isExpanded: " + parent.isExpanded + " for " + parent.name);
                      }

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -345,6 +345,9 @@ export const UxpMenuUtils = {
          console.log("append > child item: " + childItem);
          console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
+         let links = {
+            links: { childItem },
+         };
 
 
          parentItem.links = childItem;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -348,7 +348,7 @@ export const UxpMenuUtils = {
       console.log("append > child item: " + childItem);
       console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-      parentItem.links = [{ ...parentItem.links, ...childItem }];
+      parentItem.links = { ...parentItem.links, ...childItem };
 
       console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
       return true;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -177,7 +177,9 @@ export const UxpMenuUtils = {
     * @param {string} allowChildren True to allow child groupings. False to disallow children and have a single layer. If False, also removes the starting childTag, if present. 
     * @returns {Array} Returns an array of props. Props include key, itemType, text, iconProps and a custom uxpType. 
     */
-   parseNavItemText: function (rawPropText, allowChildren) {
+   parseNavItemText: function (rawPropText, disabledList, allowChildren) {
+      //Let's reasonably guarantee an array for the disabled items
+      let dList = disabledList ? disabledList : [];
 
       if (!rawPropText || typeof (rawPropText) != 'string' || rawPropText.trim().length < 1)
          return undefined;
@@ -219,17 +221,17 @@ export const UxpMenuUtils = {
 
                if (parsedItem && trimmedText) {
                   let iconName = hasChild ? undefined : parsedItem?.iconName;
-                  let props = this.getNavItemProps(i, trimmedText, iconName, false, false);
+
+                  let disabled = dList.contains(i + 1) ? true : false;
+
+                  let props = this.getNavItemProps(i, trimmedText, iconName, false, disabled);
 
                   //OK! If this is a child item, append it to the last item in the props array. If it's not, push it to the props array.
                   if (props) {
 
                      if (isChild) {
                         let parent = propsList[propsList.length - 1];
-
                         this.appendNavItemChildProps(parent, props);
-
-                        console.log("    > After appending the child: " + JSON.stringify(parent));
                      }
                      else {
                         propsList.push(props);

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -345,7 +345,9 @@ export const UxpMenuUtils = {
          console.log("append > child item: " + childItem);
          console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-         parentItem.links.concat(childItem);
+
+
+         parentItem.links = childItem;
 
          console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
          return links;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -343,20 +343,14 @@ export const UxpMenuUtils = {
    },
 
    appendNavItemChildProps: function (parentItem, childItem) {
+      if (!parentItem || !childItem)
+         return false;
 
-
-      console.log("append > child item: " + childItem);
-      console.log("       > Parent's original props: " + JSON.stringify(parentItem));
-
-      let plinks = parentItem.links.concat(childItem);
-
-      console.log("       > plinks: " + JSON.stringify(plinks));
-
-      parentItem.links = plinks;
+      parentItem.links = parentItem.links.concat(childItem);
 
       console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
-      return true;
 
+      return true;
    }
 
 };

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -174,8 +174,10 @@ export const UxpMenuUtils = {
    /**
     * Parses a complex list of raw UXPin prop text from a codeeditor for the Nav control. 
     * @param {string} rawPropText The raw UXPin prop text for a list. Pass in the raw multi-line string, entered into a Codeeditor in the Props Panel.
+    * @param {number} selectedIndex The 1-based index for the Nav control's selected index item. 
+    * @param {Array} disabledList A list of integers. The list represents 1-based indexes of items that should be disabled. 
     * @param {string} allowChildren True to allow child groupings. False to disallow children and have a single layer. If False, also removes the starting childTag, if present. 
-    * @returns {Array} Returns an array of props. Props include key, itemType, text, iconProps and a custom uxpType. 
+    * @returns {Array} Returns an array of props. Props include key, itemType, name, icon and any child groups. 
     */
    parseNavItemText: function (rawPropText, selectedIndex, disabledList, allowChildren) {
       //Let's reasonably guarantee an array for the disabled items

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -222,7 +222,7 @@ export const UxpMenuUtils = {
                if (parsedItem && trimmedText) {
                   let iconName = hasChild ? undefined : parsedItem?.iconName;
 
-                  let disabled = dList.contains(i + 1) ? true : false;
+                  let disabled = dList.includes(i + 1) ? true : false;
 
                   let props = this.getNavItemProps(i, trimmedText, iconName, false, disabled);
 

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -348,8 +348,7 @@ export const UxpMenuUtils = {
       console.log("append > child item: " + childItem);
       console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-
-      parentItem.links.concat(childItem);
+      parentItem.links = [{ ...parentItem.links, ...childItem }];
 
       console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
       return true;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -348,8 +348,15 @@ export const UxpMenuUtils = {
       console.log("append > child item: " + childItem);
       console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-      let plinks = parentItem.links;
-      parentItem.links = [{ ...plinks, childItem }];
+      var plinks = childItem;
+
+      if (parentItem.links && parentItem.links?.length > 0) {
+         plinks = parentItem.links.concat(childItem);
+      }
+
+      console.log("       > plinks: " + JSON.stringify(plinks));
+
+      parentItem.links = plinks;
 
       console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
       return true;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -177,7 +177,7 @@ export const UxpMenuUtils = {
     * @param {string} allowChildren True to allow child groupings. False to disallow children and have a single layer. If False, also removes the starting childTag, if present. 
     * @returns {Array} Returns an array of props. Props include key, itemType, text, iconProps and a custom uxpType. 
     */
-   parseNavItemText: function (rawPropText, disabledList, allowChildren) {
+   parseNavItemText: function (rawPropText, selectedIndex, disabledList, allowChildren) {
       //Let's reasonably guarantee an array for the disabled items
       let dList = disabledList ? disabledList : [];
 
@@ -221,10 +221,12 @@ export const UxpMenuUtils = {
 
                if (parsedItem && trimmedText) {
                   let iconName = hasChild ? undefined : parsedItem?.iconName;
-
                   let disabled = dList.includes(i + 1) ? true : false;
 
-                  let props = this.getNavItemProps(i, trimmedText, iconName, false, disabled);
+                  //If the index is for a parent or one of its children, expand the parent.
+                  let expanded = selectedIndex === i + 1 ? true : false;
+
+                  let props = this.getNavItemProps(i, trimmedText, iconName, expanded, disabled);
 
                   //OK! If this is a child item, append it to the last item in the props array. If it's not, push it to the props array.
                   if (props) {
@@ -232,6 +234,7 @@ export const UxpMenuUtils = {
                      if (isChild) {
                         let parent = propsList[propsList.length - 1];
                         this.appendNavItemChildProps(parent, props);
+                        parent.isExpanded = expanded;
                      }
                      else {
                         propsList.push(props);

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -350,7 +350,7 @@ export const UxpMenuUtils = {
          };
 
 
-         parentItem.links = childItem;
+         parentItem.links = links;
 
          console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
          return links;

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -348,15 +348,11 @@ export const UxpMenuUtils = {
       console.log("append > child item: " + childItem);
       console.log("       > Parent's original props: " + JSON.stringify(parentItem));
 
-      let links = {
-         links: { childItem },
-      };
 
-
-      parentItem.links = links;
+      parentItem.links.concat(childItem);
 
       console.log("       > Parent's links prop now: " + JSON.stringify(parentItem));
-      return links;
+      return true;
 
    }
 

--- a/src/components/_helpers/uxpmenuutils.js
+++ b/src/components/_helpers/uxpmenuutils.js
@@ -226,8 +226,6 @@ export const UxpMenuUtils = {
                   //If the index is for a parent or one of its children, expand the parent.
                   let expanded = selectedIndex === i + 1 ? true : false;
 
-                  console.log("      > isExpanded: " + expanded + " for " + i);
-
                   let props = this.getNavItemProps(i, trimmedText, iconName, expanded, disabled);
 
                   //OK! If this is a child item, append it to the last item in the props array. If it's not, push it to the props array.
@@ -239,8 +237,6 @@ export const UxpMenuUtils = {
 
                         if (expanded)
                            parent.isExpanded = expanded;
-
-                        console.log("      > parent.isExpanded: " + parent.isExpanded + " for " + parent.name);
                      }
                      else {
                         propsList.push(props);

--- a/src/components/_helpers/uxpstatus.js
+++ b/src/components/_helpers/uxpstatus.js
@@ -37,6 +37,27 @@ export const UxpStatus = {
       iconName: 'SkypeCircleCheck',
    },
 
+   passed: {
+      role: 'passed',
+      text: 'Passed',
+      color: 'success',
+      iconName: 'SkypeCircleCheck',
+   },
+
+   completed: {
+      role: 'completed',
+      text: 'Completed',
+      color: 'success',
+      iconName: 'SkypeCircleCheck',
+   },
+
+   approved: {
+      role: 'approved',
+      text: 'Approved',
+      color: 'success',
+      iconName: 'SkypeCircleCheck',
+   },
+
    warning: {
       role: 'warning',
       text: 'Warning',
@@ -56,6 +77,13 @@ export const UxpStatus = {
       text: 'Failed',
       color: 'error',
       iconName: 'StatusErrorFull',
+   },
+
+   overridden: {
+      role: 'overridden',
+      text: 'Overridden',
+      color: 'error',
+      iconName: 'AlertSolid',
    },
 
    skipped: {
@@ -107,6 +135,20 @@ export const UxpStatus = {
       iconName: 'Clock',
    },
 
+   pending: {
+      role: 'pending',
+      text: 'Pending',
+      color: 'neutralPrimary',
+      iconName: 'HourGlass',
+   },
+
+   validating: {
+      role: 'validating',
+      text: 'Validating',
+      color: 'neutralPrimary',
+      iconName: 'OpenEnrollment',
+   },
+
    currentStep: {
       role: 'currentStep',
       text: 'Next',
@@ -142,6 +184,20 @@ export const UxpStatus = {
       iconName: 'Info',
    },
 
+   offline: {
+      role: 'offline',
+      text: 'Offline',
+      color: 'neutralPrimary',
+      iconName: 'SkypeCircleMinus',
+   },
+
+   scheduled: {
+      role: 'scheduled',
+      text: 'Scheduled',
+      color: 'success',
+      iconName: 'Calendar',
+   },
+
    getStatusByRole: function (token) {
 
       if (token) {
@@ -159,6 +215,12 @@ export const UxpStatus = {
                return this.good;
             case 'ready':
                return this.ready;
+            case 'passed':
+               return this.passed;
+            case 'completed':
+               return this.completed;
+            case 'approved':
+               return this.approved;
             case 'warning':
                return this.warning;
             case 'error':
@@ -189,6 +251,14 @@ export const UxpStatus = {
                return this.reverted;
             case 'restored':
                return this.restored;
+            case 'offline':
+               return this.offline;
+            case 'pending':
+               return this.pending;
+            case 'validating':
+               return this.validating;
+            case 'scheduled':
+               return this.scheduled;
             default:
                return undefined;
          }
@@ -205,6 +275,9 @@ export const UxpStatus = {
       statuses.push(this.ok);
       statuses.push(this.good);
       statuses.push(this.ready);
+      statuses.push(this.passed);
+      statuses.push(this.completed);
+      statuses.push(this.approved);
       statuses.push(this.warning);
       statuses.push(this.error);
       statuses.push(this.failed);
@@ -220,6 +293,10 @@ export const UxpStatus = {
       statuses.push(this.restored);
       statuses.push(this.currentStep);
       statuses.push(this.futureStep);
+      statuses.push(this.offline);
+      statuses.push(this.pending);
+      statuses.push(this.validating);
+      statuses.push(this.scheduled);
 
       return statuses;
    }

--- a/uxpin.config.js
+++ b/uxpin.config.js
@@ -90,7 +90,6 @@ module.exports = {
           'src/components/Dialog/Dialog.js',
           'src/components/Modal/Modal.js',
           'src/components/Panel/Panel.js',
-          'src/components/ScrollablePane/ScrollablePane.js',
           'src/components/Tooltip/Tooltip.js',
         ],
       },


### PR DESCRIPTION
This update adds a long-desired feature to the Nav control: In UXPin, the user can add a star (*) before an item to support Nav item grouping. This required significant update to the UXPMenuUtils and the associated parsing logic. 

Additional notable updates: 

Facepile
We also add automatic scrolling to the Facepile's Overflow popup list.

ProfileCard
We fix a bottom padding issue on the ProfileCard and give it a min width. 

StatusSet
Added more status types.

Timestamp
This control now visible support center and right alignment. 
