### PR TITLE
bump merge cli@3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "@uxpin/merge-cli": "^3.0.3",
+    "@uxpin/merge-cli": "^3.2.0",
     "babel-loader": "^9.1.2",
     "css-loader": "6.7.3",
     "d3-shape": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,10 +2680,10 @@
   dependencies:
     "@types/node" "*"
 
-"@uxpin/merge-cli@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@uxpin/merge-cli/-/merge-cli-3.0.3.tgz#9d3617321805405cac6a3fd1e4de625150a4b393"
-  integrity sha512-xeFpBGliq02O46CccpZXNNENYAPKGicBf2+BCgibnfUN4R0s6aae6SXiD+2jDCyW/vWDiRYjkxkNpRax0XLKSw==
+"@uxpin/merge-cli@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/@uxpin/merge-cli/-/merge-cli-3.2.0.tgz#5b9e8e46d58253ef5e2d328f432be99fad1ab6af"
+  integrity sha512-H22IqqGxPB07awOryb4LCHwyK2flmfHViNfjXDPATf+RnCn2PsJ+oUFXz0nlDk7xogwa/px/5IgY6sml6E6c2w==
   dependencies:
     "@babel/core" "^7.21.8"
     "@babel/plugin-proposal-class-properties" "^7.2.3"
@@ -2696,6 +2696,7 @@
     "@types/yargs" "^16.0.0"
     "@uxpin/react-docgen-better-proptypes" "^0.1.1"
     acorn-loose "^8.0.2"
+    acorn-walk "^8.2.0"
     ast-types "^0.12.4"
     axios "^1.4.0"
     babel-loader "^8.0.5"
@@ -2704,6 +2705,7 @@
     clean-stacktrace "^1.1.0"
     clean-stacktrace-relative-paths "^1.0.4"
     commander "^2.11.0"
+    debug "^4.3.4"
     form-data "^4.0.0"
     formidable "^1.2.1"
     fs-extra "^7.0.0"
@@ -2719,6 +2721,7 @@
     p-map-series "^1.0.0"
     p-reduce "^1.0.0"
     path-sort "^0.1.0"
+    pretty-bytes "5.6.0"
     react-docgen "^4.1.0"
     require1k "^1.0.1"
     sortobject "^1.1.1"
@@ -2909,6 +2912,11 @@ acorn-loose@^8.0.2:
   integrity sha512-75lAs9H19ldmW+fAbyqHdjgdCrz0pWGXKmnqFoh8PyVd1L2RIb4RzYrSjmopeqv3E1G3/Pimu6GgLlrGbrkF7w==
   dependencies:
     acorn "^8.5.0"
+
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
 acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.2"
@@ -6152,6 +6160,11 @@ prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+pretty-bytes@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
Upgrade the merge cli package to the latest version: 3.2.0.
Check out the latest changes here: https://github.com/UXPin/uxpin-merge-tools/blob/master/packages/uxpin-merge-cli/CHANGELOG.md

